### PR TITLE
Bring AHP in line with Hacklab Conflict of Interest policies.

### DIFF
--- a/Anti-Harassment_Policy.mediawiki
+++ b/Anti-Harassment_Policy.mediawiki
@@ -77,12 +77,12 @@ A member’s identity, or the circumstances regarding any concern or complaint, 
 Members can address concerns or complaints relating to harassment based on a prohibited ground, by using the following chain of communication:
 
 #If it is appropriate, the member should tell the person who is acting in a harassing manner that it is offensive and request that s/he immediately stop. In some cases, this informal discussion may resolve the problem.
-#If this is inappropriate or if the informal discussion is not resolved, then the member should advise the Hacklab President, or another Director, or another Officer (the "Contacted Officer").
+#If this is inappropriate or if the informal discussion is not resolved, then the member should advise an Officer or Director of Hacklab (the "Contacted Officer").
 #The member will then be asked to prepare a written complaint, outlining the nature of the allegations and any important details or facts (including the name(s) of the alleged harasser(s), witnesses, dates and location of the incidents) that may assist the subsequent investigation.
 #Upon receipt of this written complaint, the Contacted Officer will immediately acknowledge its receipt to the member and will meet with the member as soon as reasonably possible.
 #The Contacted Officer will raise the issue with Hacklab's Board of Directors. In accordance with Hacklab's conflict of interest policies, any Director with a conflict of interest or an appearance of a conflict of interest, will excuse themselves.
 #The Board will exercise its discretion as to whether an internal investigation is warranted and to determine its scope. Where appropriate, the Board may conduct an investigation even if the member refuses to submit a written complaint.
-#If the Board chooses to conduct an investigation, it will select an impartial (both in fact and appearance) individual (the "Investigator") to conduct it from Hacklab's Directors and Officers.
+#If the Board chooses to conduct an investigation, it will select an impartial (both in fact and appearance) individual (the "Investigator") to conduct it.
 #The Investigator will report to the Board upon completion of their investigation. At this point the Board can consider implementing remedial action as outlined in "Mechanisms for Redress".
 
 [[category: Members]][[category: Guests]][[category: Governance]]


### PR DESCRIPTION
Previously, in Hacklab's Anti Harrassment Policy, the role of
deciding whether to investigate an allged harrassment and performing the
investigation rested with Hacklab's President. This is clearly
problematic in the scenario where the president is the victim or alleged
perpetrator. It is inconsistent with the spirit of Hacklab's Conflict
of Interest policies.

To corect for this, we split the President's role in AHP investigations
into three parts and allow for them to be handled by any Director or
Officer.

The first role, that of the Contacted Person, is an Officer or Director
the complainant feels comfortable contacting. They do not need to be
impartial, as their sole role is to bring the issue to the Board.

The second role, that of deciding whether to investigate the issue, is
placed with Hacklab's Board of Directors. (Persuant to the Conflict of
Interest Policies, Directors in a conflict of interest are absent.)

The third role, that of the investigator, is given to an impartial
individual selected by the Board.
